### PR TITLE
Update 7.1-exception.ipynb

### DIFF
--- a/7-Exception Handling/7.1-exception.ipynb
+++ b/7-Exception Handling/7.1-exception.ipynb
@@ -242,7 +242,7 @@
     "    print(ex)\n",
     "\n",
     "finally:\n",
-    "    if 'file' in locals() or not file.closed():\n",
+    "    if 'file' in locals() or not file.closed:\n",
     "        file.close()\n",
     "        print('file close')"
    ]


### PR DESCRIPTION
In the very third cell from bottom u typed <file.closed()> but <file.close> here there won't be any parenthesis as closed is not a method but a property which returns boolean value. And its not throwing error bcoz it is not getting executed as u have used <or> operator.